### PR TITLE
Add artifactName to control output filename

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "build": {
     "productName": "Firo Client",
     "appId": "com.firo.client",
+    "artifactName": "Firo-Client-${version}.${ext}",
     "asar": true,
     "protocols": {
       "name": "firo",


### PR DESCRIPTION
Add artifactName to control output filename so it uses dashes instead of spaces. Requested by @justanwar 